### PR TITLE
Use docs bot's token

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,4 +24,4 @@ jobs:
                 pip install -r requirements.txt
 
       - name: Make new issues
-        run: python upkeep.py --workdays-ahead=1 --token=${{ secrets.GH_TOKEN }}
+        run: python upkeep.py --workdays-ahead=1 --token=${{ secrets.DOCS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This is shared at an organization level. I've accepted the triage access to this repo the scrum repo as this bot.