### PR TITLE
Fix failing scrumlord job

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,8 +1,9 @@
 name: cronjob
 
 on:
+  push:
   schedule:
-    - cron: '0 15 * * *'
+    - cron: "0 15 * * *"
 
 jobs:
   cronjob:
@@ -15,13 +16,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
-        run: |
+        run: >
           python -m pip install --upgrade pip
           pip install pytest
           pip install -r requirements.txt
 
       - name: Make new issues
-        run: python upkeep.py --workdays-ahead=1 --token=${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
+        run: >
+          python upkeep.py
+              --token=${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
+              --workdays-ahead=1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -26,6 +26,6 @@ jobs:
 
       - name: Make new issues
         run: >
-          python upkeep.py
-              --token=${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
+          python upkeep.py \
+              --token=${{ secrets.DOCS_BOT_GITHUB_TOKEN }} \
               --workdays-ahead=1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,7 +3,7 @@ name: cronjob
 on:
   push:
   schedule:
-    - cron: "0 15 * * *"
+    - cron: '0 15 * * *'
 
 jobs:
   cronjob:
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Install dependencies
         run: >

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,7 +1,6 @@
 name: cronjob
 
 on:
-  push:
   schedule:
     - cron: '0 15 * * *'
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,6 +1,7 @@
 name: cronjob
 
 on:
+  push:
   schedule:
     - cron: '0 15 * * *'
 
@@ -10,18 +11,18 @@ jobs:
     env:
       TZ: America/New_York
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-                python-version: 3.6
+          python-version: 3.10
 
       - name: Install dependencies
         run: |
-                python -m pip install --upgrade pip
-                pip install pytest
-                pip install -r requirements.txt
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
 
       - name: Make new issues
         run: python upkeep.py --workdays-ahead=1 --token=${{ secrets.DOCS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: |
+        run: >
           python -m pip install --upgrade pip
           pip install pytest
           pip install -r requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,18 +8,18 @@ jobs:
     env:
       TZ: America/New_York
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-                python-version: 3.6
+          python-version: 3.10
 
       - name: Install dependencies
         run: |
-                python -m pip install --upgrade pip
-                pip install pytest
-                pip install -r requirements.txt
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
 
       - name: Run tests
         run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 holidays==0.8.1
-PyGithub==1.34
+PyGithub==1.45


### PR DESCRIPTION
Update Python version in order to fix
```
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
```
https://github.com/AlexsLemonade/scrumlord/actions/runs/3533198440/jobs/5928519077

PR summary:
  - update actions/checkout to v2 ot v3
  - update actions/setup-python v2 to v4
  - update Python to v3.6 to v3.10
  - update PyGithub v1.34 to v1.45 (to fix an error message)
  - re-format yaml files


