### PR TITLE
Fix Python deps install

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Dependencies
         run: >
-          python -m pip install --upgrade pip &
+          python -m pip install --upgrade pip &&
           pip install -r requirements.txt
 
       - name: Load 1Password secrets

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,10 +13,10 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set Up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Dependencies
         run: >
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip &
           pip install -r requirements.txt
 
       - name: Load 1Password secrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Dependencies
         run: >
-          python -m pip install --upgrade pip &
+          python -m pip install --upgrade pip &&
           pip install -r requirements.txt
 
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Dependencies
         run: >
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip &
           pip install -r requirements.txt
 
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,10 @@ jobs:
       TZ: America/New_York
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set Up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
This was a weird one. Looks like github now interprets multiple line `run` statements are interpreted as a single line. This PR fixes that by adding a `&&` at the end of the first line in the run command.

Also, in order to recreate this locally via [act](https://github.com/nektos/act) I was unable to build unless I upgraded `setup-python` to `v5`. I updated `checkout` to `v4` and tested with that as well.

Since the tests pass in GHA by downloading the same failing install dependencies step I believe this was the underlying issue.